### PR TITLE
Add GitHub Pages site for issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,5 @@
 [IMS当事人来啦！](https://github.com/fuckuestc/DoubleLuo/issues/12)  
 
 
+
+访问最新阅读页面: https://fuckuestc.github.io/DoubleLuo/

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,3 +16,5 @@
 [IMS当事人来啦！](https://github.com/fuckuestc/DoubleLuo/issues/12)  
 
 
+
+访问最新阅读页面: https://fuckuestc.github.io/DoubleLuo/

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>DoubleLuo Issues</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>DoubleLuo Issues</h1>
+  </header>
+  <main id="issues"></main>
+  <footer>
+    <p>请通过Issues提交任何内容。若你不是电子科技大学学生或教职工，请立即离开。</p>
+    <p>免责声明：本仓库的内容均来自网络公开信息，我们不保证其准确性或完整性，也不承担相关责任。</p>
+  </footer>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/docs/issue.html
+++ b/docs/issue.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Issue Detail</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1 id="title">Issue</h1>
+  </header>
+  <article id="content"></article>
+  <footer>
+    <a href="index.html">返回列表</a>
+  </footer>
+  <script src="issue.js"></script>
+</body>
+</html>

--- a/docs/issue.js
+++ b/docs/issue.js
@@ -1,0 +1,14 @@
+function getIssueNumber() {
+  const params = new URLSearchParams(window.location.search);
+  return params.get('number');
+}
+async function loadIssue() {
+  const number = getIssueNumber();
+  if (!number) return;
+  const response = await fetch(`https://api.github.com/repos/fuckuestc/DoubleLuo/issues/${number}`);
+  const issue = await response.json();
+  document.getElementById('title').textContent = issue.title;
+  const content = document.getElementById('content');
+  content.innerHTML = issue.body.replace(/\n/g, '<br>');
+}
+loadIssue();

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,0 +1,18 @@
+async function loadIssues() {
+  const response = await fetch('https://api.github.com/repos/fuckuestc/DoubleLuo/issues');
+  const issues = await response.json();
+  const container = document.getElementById('issues');
+  issues.forEach(issue => {
+    const card = document.createElement('a');
+    card.className = 'card';
+    card.href = `issue.html?number=${issue.number}`;
+    const title = document.createElement('h2');
+    title.textContent = issue.title;
+    const body = document.createElement('p');
+    body.textContent = issue.body.slice(0, 100) + (issue.body.length > 100 ? '…' : '');
+    card.appendChild(title);
+    card.appendChild(body);
+    container.appendChild(card);
+  });
+}
+loadIssues();

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,48 @@
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  margin: 0;
+  background: #f2f2f7;
+  color: #1c1c1e;
+}
+header {
+  background: #fff;
+  padding: 1rem;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+h1 { margin: 0; font-size: 1.5rem; }
+#issues {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1rem;
+  padding: 1rem;
+}
+.card {
+  background: #fff;
+  border-radius: 12px;
+  padding: 1rem;
+  box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+  display: flex;
+  flex-direction: column;
+  text-decoration: none;
+  color: inherit;
+  transition: transform 0.1s;
+}
+.card:hover { transform: translateY(-4px); }
+.card h2 {
+  font-size: 1.2rem;
+  margin-top: 0;
+}
+.card p { flex-grow: 1; }
+footer {
+  text-align: center;
+  font-size: 0.9rem;
+  padding: 1rem;
+  color: #636366;
+}
+article {
+  padding: 1rem;
+  background: #fff;
+  margin: 1rem;
+  border-radius: 12px;
+  box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+}


### PR DESCRIPTION
## Summary
- build a simple static website under `docs/` that lists all issues in a tiled view
- add page to display individual issue content
- provide minimal iOS-inspired styling and fetch issues through GitHub API
- disable Jekyll processing via `.nojekyll`
- link to the new GitHub Pages site from README files

## Testing
- `bundle exec jekyll build` *(fails: missing gem)*

------
https://chatgpt.com/codex/tasks/task_b_6855444ab55883228f641cc47d12f58d